### PR TITLE
deps: Bump pytest from 7.4.0 to 8.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ requests>=2.28.0
 # cryptography>=40.0.0
 
 # Development and testing
-pytest>=7.4.0
+pytest>=8.3.4
 pytest-asyncio>=0.21.0


### PR DESCRIPTION
Bumps pytest from 7.4.0 to 8.3.4.

**Release notes**
*Sourced from [pytest's releases](https://github.com/pytest-dev/pytest/releases).*

**Changelog**
*Sourced from [pytest's changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst).*

---
- **dependency-name**: pytest
- **dependency-type**: direct:production  
- **update-type**: version-update:semver-major

Signed-off-by: dependabot[bot] <support@github.com>