### PR TITLE
deps: Bump requests from 2.28.0 to 2.32.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Basic Python utilities
 pyyaml>=6.0
 python-dotenv>=1.0.0
-requests>=2.28.0
+requests>=2.32.3
 
 # Optional MCP dependencies (install if using MCP framework)
 # mcp>=1.0.0


### PR DESCRIPTION
Bumps requests from 2.28.0 to 2.32.3.

**Release notes**
*Sourced from [requests releases](https://github.com/psf/requests/releases).*

**Changelog**
*Sourced from [requests changelog](https://github.com/psf/requests/blob/main/HISTORY.md).*

---
- **dependency-name**: requests
- **dependency-type**: direct:production  
- **update-type**: version-update:semver-minor

Signed-off-by: dependabot[bot] <support@github.com>